### PR TITLE
fix: update test workflow to use node version 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,9 @@ jobs:
       - uses: actions/checkout@master
       - uses: snyk/actions/setup@master
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
+        with:
+          node-version: v20.13.1
       - name: Install dependencies
         run: |
           npm install
@@ -18,7 +20,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --severity-threshold=critical 
+          args: --severity-threshold=critical
   npmtest:
     runs-on: ubuntu-latest
     needs: security


### PR DESCRIPTION
Updated 'test' workflow file to use Node **v20.13.1** and **actions/setup-node@v4**

![Screen Shot 2024-05-23 at 3 31 28 PM (2)](https://github.com/snyk-labs/snyk-filter/assets/38391283/cb431f86-7876-4362-852e-bade94bbb4d6)

 

> "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/"
> 
> "The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/"