### PR TITLE
[SASD-511] fix: json output to console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .dccache
 dist
+.vscode

--- a/lib/snyk-filter.js
+++ b/lib/snyk-filter.js
@@ -164,7 +164,7 @@ function pass(data, passString, passFailMsg) {
           console.warn(
             `${chalk.yellow(
               data.projectName || data.path
-            )} - No issues found after custom filtering`
+            )} - No issues found after custom filtering.`
           );
           resolve(true);
         } else {

--- a/lib/snyk-filter.js
+++ b/lib/snyk-filter.js
@@ -20,7 +20,7 @@ var options = {
   path: path.dirname(__dirname).split(path.sep).pop(),
 };
 
-var results = []
+var results = [];
 
 function onDataCallback(data, reportCallback) {
   const jqFilterString = customFilters.filter;

--- a/lib/snyk-filter.js
+++ b/lib/snyk-filter.js
@@ -168,9 +168,10 @@ function pass(data, passString, passFailMsg) {
           );
           resolve(true);
         } else {
-          reject(
+          console.warn(
             `${chalk.yellow(data.projectName || data.path)} - ${passFailMsg}`
           );
+          resolve(true);
         }
       })
       .catch((err) => {

--- a/lib/snyk-filter.js
+++ b/lib/snyk-filter.js
@@ -20,17 +20,20 @@ var options = {
   path: path.dirname(__dirname).split(path.sep).pop(),
 };
 
+var results = []
+
 function onDataCallback(data, reportCallback) {
   const jqFilterString = customFilters.filter;
   const jqPassString = customFilters.pass;
   const failMsg = customFilters.msg;
-  data = JSON.parse(data);
+  const data = JSON.parse(data);
+  const inputLen = data.length;
   if (Array.isArray(data)) {
     data.map((dataItem) => {
-      processResults(dataItem, jqFilterString, jqPassString, failMsg);
+      processResults(dataItem, jqFilterString, jqPassString, failMsg, inputLen);
     });
   } else {
-    processResults(data, jqFilterString, jqPassString, failMsg);
+    processResults(data, jqFilterString, jqPassString, failMsg, inputLen);
   }
 }
 
@@ -81,14 +84,18 @@ function run(source, reportCallback, filters, cliOptions = null) {
   }
 }
 
-function processResults(data, filterString, passString, failMsg) {
+function processResults(data, filterString, passString, failMsg, inputLen) {
   filter(data, filterString)
     //.then((filteredData) => aggregate(filteredData))
     //.then((processedData) => {reportCallback(processedData)})
     .then((processedData) => {
       if (options && options.json) {
         console.warn("json output enabled");
-        console.log(JSON.stringify(processedData, null, 2));
+        // console.log(JSON.stringify(processedData, null, 2));
+        results.push(processedData);
+        if (results.length == inputLen || !inputLen) {
+          console.log(JSON.stringify(results));
+        }
       } else if (data.infrastructureAsCodeIssues) {
         var response = snykDisplay.displayIACResult(
           processedData,
@@ -154,7 +161,7 @@ function pass(data, passString, passFailMsg) {
     jq.run(query, data, options)
       .then((output) => {
         if (output == 0) {
-          console.info(
+          console.warn(
             `${chalk.yellow(
               data.projectName || data.path
             )} - No issues found after custom filtering`

--- a/lib/snyk-filter.js
+++ b/lib/snyk-filter.js
@@ -26,8 +26,8 @@ function onDataCallback(data, reportCallback) {
   const jqFilterString = customFilters.filter;
   const jqPassString = customFilters.pass;
   const failMsg = customFilters.msg;
-  const data = JSON.parse(data);
   const inputLen = data.length;
+  data = JSON.parse(data);
   if (Array.isArray(data)) {
     data.map((dataItem) => {
       processResults(dataItem, jqFilterString, jqPassString, failMsg, inputLen);

--- a/lib/snyk-filter.js
+++ b/lib/snyk-filter.js
@@ -26,8 +26,8 @@ function onDataCallback(data, reportCallback) {
   const jqFilterString = customFilters.filter;
   const jqPassString = customFilters.pass;
   const failMsg = customFilters.msg;
-  const inputLen = data.length;
   data = JSON.parse(data);
+  const inputLen = data.length;
   if (Array.isArray(data)) {
     data.map((dataItem) => {
       processResults(dataItem, jqFilterString, jqPassString, failMsg, inputLen);


### PR DESCRIPTION
- fix: Append filtered projects to an array (results) and then log results after all of the projects have been filtered. Before objects were logged to the console individually rather than as an array resulting in invalid json. 

- fix: Change promise state to 'resolve' when an object is filtered. The promise state was incorrectly set as 'reject' before. This kills the process and occasionally prevents the filtered results from being logged to the console.

- fix: Send the message 'No issues found after custom filtering' to warn. Before this message was sent to stdout resulting in invalid json. 